### PR TITLE
Fixing bug that causes error retrieving versions

### DIFF
--- a/src/actions/add-methods/fetchPackageVersions.ts
+++ b/src/actions/add-methods/fetchPackageVersions.ts
@@ -10,13 +10,11 @@ export default function fetchPackageVersions(selectedPackageName: string, versio
         // User has canceled the process.
         return Promise.reject(CANCEL);
     }
-    
-    selectedPackageName = selectedPackageName.toLowerCase();
 
     vscode.window.setStatusBarMessage('Loading package versions...');
 
     return new Promise((resolve) => {
-        fetch(`${versionsUrl}${selectedPackageName}/index.json`, getFetchOptions(vscode.workspace.getConfiguration('http')))
+        fetch(`${versionsUrl}${selectedPackageName.toLowerCase()}/index.json`, getFetchOptions(vscode.workspace.getConfiguration('http')))
             .then((response: Response) => {
                 clearStatusBar();
                 resolve({ response, selectedPackageName });

--- a/src/actions/add-methods/fetchPackageVersions.ts
+++ b/src/actions/add-methods/fetchPackageVersions.ts
@@ -10,6 +10,8 @@ export default function fetchPackageVersions(selectedPackageName: string, versio
         // User has canceled the process.
         return Promise.reject(CANCEL);
     }
+    
+    selectedPackageName = selectedPackageName.toLowerCase();
 
     vscode.window.setStatusBarMessage('Loading package versions...');
 


### PR DESCRIPTION
This should resolve the error "Versioning information could not be retrieved from the NuGet package repository"